### PR TITLE
Fix tab_activities.md front matter

### DIFF
--- a/tab_activities.md
+++ b/tab_activities.md
@@ -1,5 +1,6 @@
 ---
-title: Meeting Minutes
+title: activities
+displaytext: Meeting Minutes
 layout:  null
 tab: true
 order: 1


### PR DESCRIPTION
Apparently the `title` element must jive with the filename.